### PR TITLE
Bump version of trivy-action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
         save-always: true
     -
       name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.20.0
+      uses: aquasecurity/trivy-action@0.29.0
       with:
         image-ref: "${{ inputs.docker-image-name }}"
         format: 'table'


### PR DESCRIPTION
This is so we can finally get rid of those pesky scan failures due to download rate limits.