### PR TITLE
⬆️ Update trivy-action to v0.35.0 hash after security tag removal

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
         save-always: true
     -
       name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.29.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
       with:
         image-ref: "${{ inputs.docker-image-name }}"
         format: 'table'

--- a/security-trivy-critical/action.yml
+++ b/security-trivy-critical/action.yml
@@ -16,7 +16,7 @@ runs:
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
       with:
         scan-type: 'fs'
         ignore-unfixed: true

--- a/security-trivy/action.yml
+++ b/security-trivy/action.yml
@@ -16,7 +16,7 @@ runs:
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
       with:
         format: table
         scan-type: 'fs'


### PR DESCRIPTION
Pin trivy-action to v0.35.0 commit hash (57a97c7) across all 3 action files after upstream security tag removal broke previous references.

You might need to allow aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1